### PR TITLE
feat: Add Google Veo video generation and Qwen image edit models

### DIFF
--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -298,12 +298,38 @@ CATALOG: List[Model] = [
         capabilities=Capability.VIDEO_GENERATION,
         display_name="Seedance 1 Lite",
     ),
+    # Video generation (Google)
+    Model(
+        id="veo-3.0-generate-preview",
+        provider=Provider.GOOGLE,
+        capabilities=Capability.VIDEO_GENERATION,
+        display_name="Veo 3.0 Preview",
+    ),
+    Model(
+        id="veo-3.0-fast-generate-preview",
+        provider=Provider.GOOGLE,
+        capabilities=Capability.VIDEO_GENERATION,
+        display_name="Veo 3.0 Fast Preview",
+    ),
+    Model(
+        id="veo-2.0-generate-001",
+        provider=Provider.GOOGLE,
+        capabilities=Capability.VIDEO_GENERATION,
+        display_name="Veo 2.0",
+    ),
     # Replicate Image Generation Models
     Model(
         id="stability-ai/sdxl",
         provider=Provider.REPLICATE,
         capabilities=Capability.IMAGE_GENERATION,
         display_name="Stable Diffusion XL",
+    ),
+    # Replicate Image Edit Models
+    Model(
+        id="qwen/qwen-image-edit",
+        provider=Provider.REPLICATE,
+        capabilities=Capability.IMAGE_EDIT,
+        display_name="Qwen Image Edit",
     ),
     Model(
         id="stability-ai/stable-diffusion",


### PR DESCRIPTION
## Summary
- Added Google Veo models (3.0 Preview, 3.0 Fast Preview, and 2.0) for video generation capabilities
- Added Qwen Image Edit model for image editing via Replicate provider
- Expanded the model catalog to include latest AI offerings from Google and Replicate

## Changes
- **Google Veo Video Models**: Three new video generation models from Google's Veo family
  - `veo-3.0-generate-preview`: Veo 3.0 Preview
  - `veo-3.0-fast-generate-preview`: Veo 3.0 Fast Preview  
  - `veo-2.0-generate-001`: Veo 2.0
- **Qwen Image Edit**: New image editing model `qwen/qwen-image-edit` via Replicate

## Test Plan
- [ ] Verify models are correctly registered in the catalog
- [ ] Confirm provider and capability mappings are accurate
- [ ] Test that the registry API properly returns these new models
- [ ] Validate display names are shown correctly in UI/API responses