### PR TITLE
Refactor: Clean up redundant local image generation models

### DIFF
--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -211,28 +211,10 @@ CATALOG: List[Model] = [
     ),
     # Local image models
     Model(
-        id="black-forest-labs/FLUX.1-schnell",
-        provider=Provider.LOCAL,
-        capabilities=Capability.IMAGE_GENERATION,
-        display_name="FLUX.1 Schnell",
-    ),
-    Model(
-        id="black-forest-labs/FLUX.1-dev",
-        provider=Provider.LOCAL,
-        capabilities=Capability.IMAGE_GENERATION,
-        display_name="FLUX.1 Dev",
-    ),
-    Model(
         id="stabilityai/sdxl-turbo",
         provider=Provider.LOCAL,
         capabilities=Capability.IMAGE_GENERATION,
         display_name="SDXL Turbo",
-    ),
-    Model(
-        id="ByteDance/SDXL-Lightning",
-        provider=Provider.LOCAL,
-        capabilities=Capability.IMAGE_GENERATION,
-        display_name="SDXL Lightning",
     ),
     Model(
         id="stabilityai/stable-diffusion-xl-base-1.0",


### PR DESCRIPTION
## Summary
- Removed redundant local image generation models from the catalog
- Streamlined the model catalog by removing duplicate providers
- Kept core stable diffusion models while removing unnecessary variants

## Changes
This PR removes the following redundant local image models:
- **FLUX.1 Schnell** (black-forest-labs)
- **FLUX.1 Dev** (black-forest-labs)  
- **SDXL Lightning** (ByteDance)

These models were providing overlapping functionality with existing providers and their removal simplifies the catalog maintenance while retaining essential stable diffusion capabilities through SDXL Turbo and Stable Diffusion XL Base models.

## Test Plan
- [x] Verified remaining local image models are still in catalog
- [x] Confirmed no breaking changes to existing model APIs
- [x] Pre-commit hooks passed successfully