### PR TITLE
Allow CelesteSettings to ignore extra env vars

### DIFF
--- a/src/celeste_core/config/settings.py
+++ b/src/celeste_core/config/settings.py
@@ -82,6 +82,7 @@ class CelesteSettings(BaseSettings):
         env_file_encoding="utf-8",
         populate_by_name=True,
         env_nested_delimiter="__",
+        extra="ignore",
     )
     openai: OpenAISettings = Field(default_factory=OpenAISettings)
     google: GoogleSettings = Field(default_factory=GoogleSettings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from celeste_core.config.settings import CelesteSettings
+
+def test_extra_env_fields_are_ignored(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "testkey")
+    monkeypatch.setenv("CUSTOM_VAR", "hello")
+    settings = CelesteSettings()
+    assert settings.openai.api_key == "testkey"
+    assert not hasattr(settings, "custom_var")


### PR DESCRIPTION
## Summary
- allow extra values in CelesteSettings `.env` files
- add regression test for extra env var handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f1887d1c832ca7ad5b5ec655989c