### PR TITLE
Add document intelligence capability to Gemini vision models

### DIFF
--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -40,7 +40,8 @@ CATALOG: List[Model] = [
         provider=Provider.GOOGLE,
         capabilities=Capability.TEXT_GENERATION
         | Capability.STRUCTURED_OUTPUT
-        | Capability.VISION,
+        | Capability.VISION
+        | Capability.DOCUMENT_INTELLIGENCE,
         display_name="Gemini 2.5 Flash",
     ),
     Model(
@@ -48,7 +49,8 @@ CATALOG: List[Model] = [
         provider=Provider.GOOGLE,
         capabilities=Capability.TEXT_GENERATION
         | Capability.STRUCTURED_OUTPUT
-        | Capability.VISION,
+        | Capability.VISION
+        | Capability.DOCUMENT_INTELLIGENCE,
         display_name="Gemini 2.5 Pro",
     ),
     Model(
@@ -57,7 +59,8 @@ CATALOG: List[Model] = [
         capabilities=Capability.TEXT_GENERATION
         | Capability.STRUCTURED_OUTPUT
         | Capability.VISION
-        | Capability.AUDIO_TRANSCRIPTION,
+        | Capability.AUDIO_TRANSCRIPTION
+        | Capability.DOCUMENT_INTELLIGENCE,
         display_name="Gemini 2.5 Flash Lite",
     ),
     Model(

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,13 @@
+from celeste_core.enums.capability import Capability
+from celeste_core.enums.providers import Provider
+from celeste_core.models.catalog import CATALOG
+
+
+def test_gemini_vision_models_have_document_intelligence():
+    for model in CATALOG:
+        if (
+            model.provider == Provider.GOOGLE
+            and model.id.startswith("gemini")
+            and model.capabilities & Capability.VISION
+        ):
+            assert model.capabilities & Capability.DOCUMENT_INTELLIGENCE


### PR DESCRIPTION
## Summary
- mark Gemini 2.5 Flash, 2.5 Pro, and 2.5 Flash Lite models with DOCUMENT_INTELLIGENCE
- add regression test ensuring Gemini vision models advertise document intelligence

## Testing
- `pre-commit run --files src/celeste_core/models/catalog.py tests/test_model_catalog.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe8bccb8832cb5f2a42ac8749114