### PR TITLE
Add reranking capability to celeste-core

### DIFF
--- a/src/celeste_core/base/reranker.py
+++ b/src/celeste_core/base/reranker.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List, Union
+
+from celeste_core.types.response import AIResponse
+
+
+class BaseReranker(ABC):
+    @abstractmethod
+    def __init__(self, **kwargs: Any) -> None:  # pragma: no cover - interface only
+        """Initialize provider reranker; provider-specific args via kwargs."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def rerank(
+        self, query: str, texts: Union[str, List[str]], top_k: int = 5, **kwargs: Any
+    ) -> AIResponse[List[str]]:
+        """Rerank texts based on relevance to query.
+
+        Returns an AIResponse whose content is the reranked texts in relevance order.
+        Scores and original indices are available in metadata.
+        Single-string inputs return a list with a single text to keep the
+        return shape consistent.
+        """
+        raise NotImplementedError

--- a/src/celeste_core/config/settings.py
+++ b/src/celeste_core/config/settings.py
@@ -76,6 +76,12 @@ class ReplicateSettings(BaseModel):
     )
 
 
+class CohereSettings(BaseModel):
+    api_key: Optional[str] = Field(
+        default_factory=lambda: os.getenv("COHERE_API_KEY"), alias="COHERE_API_KEY"
+    )
+
+
 class CelesteSettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -93,6 +99,7 @@ class CelesteSettings(BaseSettings):
     luma: LumaSettings = Field(default_factory=LumaSettings)
     xai: XAISettings = Field(default_factory=XAISettings)
     replicate: ReplicateSettings = Field(default_factory=ReplicateSettings)
+    cohere: CohereSettings = Field(default_factory=CohereSettings)
 
     # Pydantic v2 SettingsConfigDict above replaces old Config
 
@@ -121,6 +128,8 @@ class CelesteSettings(BaseSettings):
             missing.append("XAI_API_KEY")
         if p == "replicate" and not self.replicate.api_token:
             missing.append("REPLICATE_API_TOKEN")
+        if p == "cohere" and not self.cohere.api_key:
+            missing.append("COHERE_API_KEY")
 
         if missing:
             raise ValueError(
@@ -145,6 +154,7 @@ class CelesteSettings(BaseSettings):
             "luma": {"api_key": mask(self.luma.api_key)},
             "xai": {"api_key": mask(self.xai.api_key)},
             "replicate": {"api_token": mask(self.replicate.api_token)},
+            "cohere": {"api_key": mask(self.cohere.api_key)},
         }
 
 

--- a/src/celeste_core/enums/capability.py
+++ b/src/celeste_core/enums/capability.py
@@ -20,6 +20,7 @@ class Capability(IntFlag):
     STRUCTURED_OUTPUT = 1 << 8
     FUNCTION_CALLING = 1 << 9
     VISION = 1 << 10
+    RERANKING = 1 << 11
 
 
 __all__ = ["Capability"]

--- a/src/celeste_core/enums/providers.py
+++ b/src/celeste_core/enums/providers.py
@@ -14,3 +14,4 @@ class Provider(Enum):
     LUMA = "luma"
     XAI = "xai"
     REPLICATE = "replicate"
+    COHERE = "cohere"

--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -513,6 +513,31 @@ CATALOG: List[Model] = [
         capabilities=Capability.TEXT_GENERATION,
         display_name="GPT OSS 20B (Ollama)",
     ),
+    # Cohere reranking models
+    Model(
+        id="rerank-multilingual-v3.0",
+        provider=Provider.COHERE,
+        capabilities=Capability.RERANKING,
+        display_name="Rerank Multilingual v3.0",
+    ),
+    Model(
+        id="rerank-english-v3.0",
+        provider=Provider.COHERE,
+        capabilities=Capability.RERANKING,
+        display_name="Rerank English v3.0",
+    ),
+    Model(
+        id="rerank-multilingual-v2.0",
+        provider=Provider.COHERE,
+        capabilities=Capability.RERANKING,
+        display_name="Rerank Multilingual v2.0",
+    ),
+    Model(
+        id="rerank-english-v2.0",
+        provider=Provider.COHERE,
+        capabilities=Capability.RERANKING,
+        display_name="Rerank English v2.0",
+    ),
 ]
 
 


### PR DESCRIPTION
## 🎯 Add Reranking Capability to Celeste Core

This PR adds comprehensive reranking support to celeste-core, enabling the new **celeste-reranking** domain package.

### ✨ Features Added

- **🎯 RERANKING capability** - New capability enum for reranking models
- **🎨 COHERE provider** - New provider enum for Cohere reranking services  
- **⚙️ CohereSettings** - API key validation and settings integration
- **🏗️ BaseReranker** - Abstract base class following Celeste patterns
- **📊 Reranking models** - 4 Cohere models added to catalog

### 🔧 Implementation Details

**BaseReranker Interface:**
```python
async def rerank(
    self, query: str, texts: Union[str, List[str]], top_k: int = 5, **kwargs: Any
) -> AIResponse[List[str]]:
```

**Clean Response Pattern:**
- `content`: Reranked texts in relevance order
- `metadata`: Scores and original indices
- Follows standard `AIResponse[List[str]]` pattern

**Settings Integration:**
- `COHERE_API_KEY` environment variable
- Proper validation in `settings.validate_for_provider("cohere")`

### 🎨 Catalog Models Added

- `rerank-multilingual-v3.0` - Latest multilingual model
- `rerank-english-v3.0` - Latest English-only model  
- `rerank-multilingual-v2.0` - Legacy multilingual model
- `rerank-english-v2.0` - Legacy English-only model

### 🚀 Enables celeste-reranking Package

This core infrastructure enables the new **celeste-reranking** domain package with:
- Factory pattern: `create_reranker(provider, model=model)`
- Unified API across reranking providers
- Seamless integration with existing Celeste ecosystem

### ✅ Testing

- ✅ Pre-commit hooks pass
- ✅ Follows all existing Celeste patterns
- ✅ Ready for celeste-reranking integration

🌟 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>