### PR TITLE
Standardize model attribute name across all base clients

### DIFF
--- a/src/celeste_core/base/audio_client.py
+++ b/src/celeste_core/base/audio_client.py
@@ -17,7 +17,7 @@ class BaseAudioClient(ABC):
     ) -> None:
         """Initialize audio transcription client with validation logic."""
         validate_client_config(model, provider, Capability.AUDIO_TRANSCRIPTION)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_content(

--- a/src/celeste_core/base/client.py
+++ b/src/celeste_core/base/client.py
@@ -17,7 +17,7 @@ class BaseClient(ABC):
     ) -> None:
         """Initialize text generation client with validation logic."""
         validate_client_config(model, provider, Capability.TEXT_GENERATION)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_content(

--- a/src/celeste_core/base/document_client.py
+++ b/src/celeste_core/base/document_client.py
@@ -17,7 +17,7 @@ class BaseDocClient(ABC):
     ) -> None:
         """Initialize document intelligence client with validation logic."""
         validate_client_config(model, provider, Capability.DOCUMENT_INTELLIGENCE)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_content(self, prompt: str, documents: Any, **kwargs: Any) -> Any:

--- a/src/celeste_core/base/embedder.py
+++ b/src/celeste_core/base/embedder.py
@@ -15,7 +15,7 @@ class BaseEmbedder(ABC):
     ) -> None:
         """Initialize embedder with validation logic."""
         validate_client_config(model, provider, Capability.EMBEDDINGS)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_embeddings(

--- a/src/celeste_core/base/image_editor.py
+++ b/src/celeste_core/base/image_editor.py
@@ -15,7 +15,7 @@ class BaseImageEditor(ABC):
     ) -> None:
         """Initialize image editor with validation logic."""
         validate_client_config(model, provider, Capability.IMAGE_EDIT)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def edit_image(

--- a/src/celeste_core/base/image_enhancer.py
+++ b/src/celeste_core/base/image_enhancer.py
@@ -15,7 +15,7 @@ class BaseImageEnhancer(ABC):
     ) -> None:
         """Initialize image enhancer with validation logic."""
         validate_client_config(model, provider, Capability.IMAGE_ENHANCE)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def enhance_image(self, image: ImageArtifact, **kwargs: Any) -> ImageArtifact:

--- a/src/celeste_core/base/image_generator.py
+++ b/src/celeste_core/base/image_generator.py
@@ -15,7 +15,7 @@ class BaseImageGenerator(ABC):
     ) -> None:
         """Initialize image generator with validation logic."""
         validate_client_config(model, provider, Capability.IMAGE_GENERATION)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_image(self, prompt: str, **kwargs: Any) -> List[ImageArtifact]:

--- a/src/celeste_core/base/reranker.py
+++ b/src/celeste_core/base/reranker.py
@@ -15,7 +15,7 @@ class BaseReranker(ABC):
     ) -> None:
         """Initialize reranker with validation logic."""
         validate_client_config(model, provider, Capability.RERANKING)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def rerank(

--- a/src/celeste_core/base/tts_client.py
+++ b/src/celeste_core/base/tts_client.py
@@ -15,7 +15,7 @@ class BaseTTSClient(ABC):
     ) -> None:
         """Initialize TTS client with validation logic."""
         validate_client_config(model, provider, Capability.TEXT_TO_SPEECH)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_speech(

--- a/src/celeste_core/base/video_client.py
+++ b/src/celeste_core/base/video_client.py
@@ -17,7 +17,7 @@ class BaseVideoClient(ABC):
     ) -> None:
         """Initialize video generation client with validation logic."""
         validate_client_config(model, provider, Capability.VIDEO_GENERATION)
-        self.model_name = model
+        self.model = model
 
     @abstractmethod
     async def generate_content(self, prompt: str, **kwargs: Any) -> Any:


### PR DESCRIPTION
## Summary
• Rename `model_name` attribute to `model` across all base client classes for consistency
• This change affects all base client types: audio, document, embedder, image editor/enhancer/generator, reranker, TTS, video, and text generation clients
• Maintains existing functionality while improving code consistency and readability

## Test plan
- [x] All pre-commit hooks pass (ruff, format checks, etc.)
- [ ] Verify no breaking changes in dependent implementations
- [ ] Run existing test suite to ensure compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)