### PR TITLE
Fix Python 3.12+ generics syntax and linting

### DIFF
--- a/src/celeste_core/models/registry.py
+++ b/src/celeste_core/models/registry.py
@@ -62,7 +62,7 @@ def supports(provider: Provider, model_id: str, cap: Capability) -> bool:
 
 def reload_catalog() -> None:
     """Reload the built-in Python catalog into the registry."""
-    from celeste_core.models.catalog import CATALOG
+    from celeste_core.models.catalog import CATALOG  # noqa: PLC0415
 
     clear_registry()
     for model in CATALOG:

--- a/src/celeste_core/types/response.py
+++ b/src/celeste_core/types/response.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from celeste_core.enums.providers import Provider
 
-T = TypeVar("T")
 
-
-class AIResponse(BaseModel, Generic[T]):
+class AIResponse[T](BaseModel):
     """Generic AI response wrapper used across domains.
 
     The content type parameter T allows domains to specify their payloads:


### PR DESCRIPTION
## Summary
- Update `AIResponse` class to use Python 3.12+ generic syntax (PEP 695)
- Add noqa comment to suppress import-outside-toplevel warning in registry.py
- Modernize code to align with Python 3.12+ standards

## Test plan
- [x] Pre-commit hooks pass
- [x] Code follows Python 3.12+ syntax patterns
- [ ] Existing tests pass without modifications

🤖 Generated with [Claude Code](https://claude.ai/code)