### PR TITLE
Add HunyuanImage 2.1 to Hugging Face catalog

### DIFF
--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -218,6 +218,12 @@ CATALOG: list[Model] = [
         capabilities=Capability.IMAGE_GENERATION,
         display_name="Qwen Image",
     ),
+    Model(
+        id="tencent/HunyuanImage-2.1",
+        provider=Provider.HUGGINGFACE,
+        capabilities=Capability.IMAGE_GENERATION,
+        display_name="HunyuanImage 2.1",
+    ),
     # Local image models
     Model(
         id="stabilityai/sdxl-turbo",


### PR DESCRIPTION
## Summary
- add the HunyuanImage 2.1 Hugging Face model to the image generation catalog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c911f0392c832cb46e54aa1ad2ca76