### PR TITLE
Set Tencent SRPO capability to image generation

### DIFF
--- a/src/celeste_core/models/catalog.py
+++ b/src/celeste_core/models/catalog.py
@@ -224,6 +224,12 @@ CATALOG: list[Model] = [
         capabilities=Capability.IMAGE_GENERATION,
         display_name="HunyuanImage 2.1",
     ),
+    Model(
+        id="tencent/SRPO",
+        provider=Provider.HUGGINGFACE,
+        capabilities=Capability.IMAGE_GENERATION,
+        display_name="SRPO",
+    ),
     # Local image models
     Model(
         id="stabilityai/sdxl-turbo",


### PR DESCRIPTION
## Summary
- update the Tencent SRPO catalog entry to use the image generation capability so it surfaces with other generative models

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91586b3a0832c9ee3d5d22ac72907